### PR TITLE
fix/redis-url-loading

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,10 +23,10 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    uri = URI.parse(ENV['REDIS_URL'])
-    config.cache_store = :redis_store, {
-      host: uri.host || 'redis',
-      port: uri.port || 6379,
+    uri = URI.parse(ENV['REDIS_URL']) unless ENV['REDIS_URL'].nil?
+      config.cache_store = :redis_store, {
+      host: uri&.host || 'redis',
+      port: uri&.port || 6379,
       db: 1,
       namespace: 'cache'
     },

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-uri = URI.parse(ENV['REDIS_URL'])
+uri = URI.parse(ENV['REDIS_URL']) unless ENV['REDIS_URL'].nil?
 
 Rails.application.config.session_store :redis_store, {
   servers: [
     {
-      host: uri.host || 'redis',
-      port: uri.port || 6379,
+      host: uri&.host || 'redis',
+      port: uri&.port || 6379,
       db: 0,
       namespace: 'session'
     }


### PR DESCRIPTION
`docker-compose build`時に出たエラーを回避するための処理を記述

- エラーの原因については不明
- `docker-compose run --rm app bin/rails db:create`でredisのイメージがpullされてたっぽいのでそれが原因かも